### PR TITLE
Generate preview of documentation for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+# .github/workflows/pull-request-links.yaml
+
+name: readthedocs/actions
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  pull-request-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "computing-docs"


### PR DESCRIPTION
This adds a workflow to add a link to preview the documentation that is built for each pull request. This should hopefully make future PRs easier to evaluate.

@swnesbitt This may require changes on readthedocs to enable the feature (Under the Admin dashboard, Advanced Settings -> Build pull requests for this project)