### PR TITLE
Add readthedocs.yaml file for configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py


### PR DESCRIPTION
(Hopefully) addresses the issue of the build failing on readthedocs.

<!-- readthedocs-preview computing-docs start -->
----
:books: Documentation preview :books:: https://computing-docs--5.org.readthedocs.build/en/5/

<!-- readthedocs-preview computing-docs end -->