### PR TITLE
Add E3SM to codes.rst

### DIFF
--- a/docs/source/codes.rst
+++ b/docs/source/codes.rst
@@ -7,5 +7,6 @@ Models that have been configured and installed on Keeling
    :maxdepth: 2 
 
    CESM <cesm/cesm>
+   E3SM <e3sm>
    PartMC <partmc>
    WRF <wrf>


### PR DESCRIPTION
Added the link to E3SM docs for keeling to "Commonly Installed model codes"

<!-- readthedocs-preview computing-docs start -->
----
📚 Documentation preview 📚: https://computing-docs--18.org.readthedocs.build/en/18/

<!-- readthedocs-preview computing-docs end -->